### PR TITLE
feat: better x axis display

### DIFF
--- a/script/results.js
+++ b/script/results.js
@@ -81,6 +81,9 @@ window.onload = () => {
 					max: 1,
 					ticks: {
 						stepSize: 0.1,
+						callback: function (val) {
+							return `${val * 100}%`;
+						},
 					},
 				},
 			},


### PR DESCRIPTION
The `x` axis on the results page now displays the percent rather than the raw probability.

Closes #5